### PR TITLE
typer 0.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,7 @@ test:
     - typer
   requires:
     - pip
+    - python <3.10
   commands:
     - pip check
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "typer" %}
-{% set version = "0.3.2" %}
+{% set version = "0.4.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 5455d750122cff96745b0dec87368f56d023725a7ebc9d2e54dd23dc86816303
+  sha256: 63c3aeab0549750ffe40da79a1b524f60e08a2cbc3126c520ebf2eeaf507f5dd
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,18 +10,22 @@ source:
   sha256: 63c3aeab0549750ffe40da79a1b524f60e08a2cbc3126c520ebf2eeaf507f5dd
 
 build:
+  skip: True  # [py<36]
   noarch: python
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
     - flit-core >=2,<3
+    - setuptools
+    - wheel
   run:
     - python >=3.6
-    - click >=7.1.1,<7.2.0
+    - click >=7.1.1,<9.0.0
+    # Requires extra
     - colorama >=0.4.3,<0.5.0
     - shellingham >=1.3.0,<2.0.0
 


### PR DESCRIPTION
Update typer to 0.4.0

Version change: bump version number from 0.3.2 to 0.4.0
Bug Tracker: new open issues https://github.com/tiangolo/typer/issues
Github releases:  https://github.com/tiangolo/typer/releases
Upstream license:  License file:  https://github.com/tiangolo/typer/blob/master/LICENSE
Upstream pyproject.toml:  https://github.com/tiangolo/typer/blob/0.4.0/pyproject.toml

The package typer is mentioned inside the packages:
pathy | 

Actions:
1. Add missing packages
2. Update dependencies

Result:
- all-succeeded