### PR TITLE
anaconda.yaml: add typer to packages (PKG-14099)

### DIFF
--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -3,6 +3,7 @@ upstream_sources:
   - pypi:
       identifier: typer
     packages:
+      - typer
       - typer-cli
       - typer-slim
       - typer-slim-standard


### PR DESCRIPTION
Include the primary `typer` output in `anaconda.yaml` for parity with recipe/meta.yaml multi-output list.

Refs PKG-14099.

Made with [Cursor](https://cursor.com)